### PR TITLE
[vle.output] fix missing 'time' string

### DIFF
--- a/vle.output/src/vle/oov/Storage.cpp
+++ b/vle.output/src/vle/oov/Storage.cpp
@@ -154,6 +154,7 @@ public:
 
         if (m_headertype == STORAGE_HEADER_TOP) {
             m_matrix->addRow();
+            m_matrix->add(0, 0, new vle::value::String("time"));
         }
     }
 


### PR DESCRIPTION
The name of the first column ('time') was missing for the plugin
'storage'
