### PR TITLE
de: fix a segfault GUI

### DIFF
--- a/vle.extension.difference-equation/src/vle/gvle/modeling/difference-equation/Mapping.cpp
+++ b/vle.extension.difference-equation/src/vle/gvle/modeling/difference-equation/Mapping.cpp
@@ -160,9 +160,6 @@ void Mapping::MappingTreeView::onEdit()
 
 Mapping::~Mapping()
 {
-    delete m_RadioButtonName;
-    delete m_RadioButtonPort;
-    delete m_RadioButtonMapping;
 }
 
 void Mapping::assign(vpz::Condition& condition)


### PR DESCRIPTION
When calling the experimental condition of the modeling plugin of the
difference-equation on a port parameter, gvle was ending directly with
a segfault. A wrong implementation of a destructor has been fixed.
