### PR TITLE
fix FindVLE.cmake & FindGVLE.cmake

### DIFF
--- a/vle.examples/cmake/FindVLE.cmake
+++ b/vle.examples/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.extension.celldevs/cmake/FindVLE.cmake
+++ b/vle.extension.celldevs/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.extension.cellqss/cmake/FindVLE.cmake
+++ b/vle.extension.cellqss/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.extension.decision/cmake/FindVLE.cmake
+++ b/vle.extension.decision/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.extension.difference-equation/cmake/FindVLE.cmake
+++ b/vle.extension.difference-equation/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.extension.differential-equation/cmake/FindVLE.cmake
+++ b/vle.extension.differential-equation/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.extension.dsdevs/cmake/FindVLE.cmake
+++ b/vle.extension.dsdevs/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.extension.fsa/cmake/FindVLE.cmake
+++ b/vle.extension.fsa/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.extension.petrinet/cmake/FindVLE.cmake
+++ b/vle.extension.petrinet/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")

--- a/vle.forrester/cmake/FindGVLE.cmake
+++ b/vle.forrester/cmake/FindGVLE.cmake
@@ -141,7 +141,7 @@ endif ()
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(GVLE REQUIRED_VARS
-  GVLE_INCLUDE_DIRS  GVLE_LIBRARY_DIRS GVLE_LIBRARIES)
+  GVLE_INCLUDE_DIRS GVLE_LIBRARIES)
 
 if (${_gvle_debug})
   message (" gvle_debug GVLE_INCLUDE_DIRS ${GVLE_INCLUDE_DIRS}")

--- a/vle.output/cmake/FindGVLE.cmake
+++ b/vle.output/cmake/FindGVLE.cmake
@@ -141,7 +141,7 @@ endif ()
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(GVLE REQUIRED_VARS
-  GVLE_INCLUDE_DIRS  GVLE_LIBRARY_DIRS GVLE_LIBRARIES)
+  GVLE_INCLUDE_DIRS GVLE_LIBRARIES)
 
 if (${_gvle_debug})
   message (" gvle_debug GVLE_INCLUDE_DIRS ${GVLE_INCLUDE_DIRS}")

--- a/vle.output/cmake/FindVLE.cmake
+++ b/vle.output/cmake/FindVLE.cmake
@@ -127,7 +127,7 @@ endif (${_find_vle_using_cmake})
 # listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(VLE REQUIRED_VARS VLE_INCLUDE_DIRS
-                        VLE_LIBRARY_DIRS VLE_LIBRARIES)
+                        VLE_LIBRARIES)
 
 if (${_vle_debug})
   message (" vle_debug VLE_INCLUDE_DIRS ${VLE_INCLUDE_DIRS}")


### PR DESCRIPTION
don't search for VLE_LIBRARY_DIRS or GVLE_LIBRARY_DIRS
fix #37 for case of vle install in /usr
