### PR TITLE
decision: add a relative date to year concept

### DIFF
--- a/vle.extension.decision/src/vle/gvle/modeling/decision/Decision.cpp
+++ b/vle.extension.decision/src/vle/gvle/modeling/decision/Decision.cpp
@@ -59,9 +59,13 @@ ActivityModel::ActivityModel(const std::string& conf):
 
     if (activityModel[7] == "R") {
         mIsRelativeDate = true;
-    }
-    else {
+        mIsHumanDate = false;
+    } else if (activityModel[7] == "Y") {
+        mIsRelativeDate = true;
+        mIsHumanDate = true;
+    } else {
         mIsRelativeDate = false;
+        mIsHumanDate = false;
     }
 
     computeAnchors();
@@ -99,6 +103,31 @@ ActivityModel* Decision::getActivityByName(string activityName) const
 const strings_t Decision::getPredicates(string ruleName) const
 {
     return getRule()->find(ruleName)->second;
+}
+
+const std::string Decision::toHumanRelativeDate(double numericDate) const
+{
+ std::string humanDate;
+
+ int year = numericDate/365;
+
+ int daysAfter1Jan = (int)numericDate % 365;
+
+ long aYearNotLeap = utils::DateTime::toJulianDayNumber("1400-12-31");
+
+ double aDate = aYearNotLeap + daysAfter1Jan;
+
+ int month =  utils::DateTime::month(aDate);
+
+ int day =  utils::DateTime::dayOfMonth(aDate);
+
+ std::string yS = boost::lexical_cast<std::string>(year);
+ std::string mS = boost::lexical_cast<std::string>(month);
+ std::string dS = boost::lexical_cast<std::string>(day);
+
+ humanDate = yS + "-" + mS + "-" + dS;
+
+ return humanDate;
 }
 
 const std::string Decision::getActivityCard(string activityName) const

--- a/vle.extension.decision/src/vle/gvle/modeling/decision/Decision.hpp
+++ b/vle.extension.decision/src/vle/gvle/modeling/decision/Decision.hpp
@@ -40,6 +40,7 @@
 #include <fstream>
 #include <vector>
 #include <map>
+
 using namespace std;
 
 namespace vle {
@@ -273,6 +274,7 @@ public:
         mName(name), mX(x), mY(y), mWidth(w), mHeight(h), mMinstart(""),
         mMaxfinish("")
     {
+        mIsHumanDate = true;
         mIsRelativeDate = false;
         computeAnchors();
     }
@@ -514,7 +516,17 @@ public:
 
     bool getRelativeDate() const
     {
-        return (mIsRelativeDate == true);
+        return mIsRelativeDate;
+    }
+
+    bool isHumanDate() const
+    {
+        return mIsHumanDate;
+    }
+
+    void setHumanDate(bool state)
+    {
+        mIsHumanDate = state;
     }
 
 private:
@@ -528,6 +540,7 @@ private:
     std::string mMinstart;
     std::string mMaxfinish;
     bool mIsRelativeDate;
+    bool mIsHumanDate;
 
     points_t mAnchors;
 
@@ -669,6 +682,13 @@ public:
     }
 
     ActivityModel* getActivityByName(string activityName) const;
+
+/**
+ * @brief Convert a double to a Human Date
+ * @param Numeric date
+ * @return Human date
+ */
+    const std::string toHumanRelativeDate(double numericDate) const;
 
 /**
  * @brief Return the ActivityModel card : the description displayed in a tooltip

--- a/vle.extension.decision/src/vle/gvle/modeling/decision/DecisionDrawingArea.cpp
+++ b/vle.extension.decision/src/vle/gvle/modeling/decision/DecisionDrawingArea.cpp
@@ -529,6 +529,7 @@ bool DecisionDrawingArea::modifyCurrentActivityModel()
                                              dialog.name());
             }
             activityModel->setRelativeDate(dialog.isRelativeDate());
+            activityModel->setHumanDate(dialog.isHumanDate());
             checkSize(activityModel, activityModel->name());
 
             int newWidth = activityModel->x() + activityModel->width() + OFFSET;

--- a/vle.extension.decision/src/vle/gvle/modeling/decision/Plugin.cpp
+++ b/vle.extension.decision/src/vle/gvle/modeling/decision/Plugin.cpp
@@ -587,7 +587,7 @@ void PluginDecision::generateSource(const std::string& classname,
         std::string esp8 = "        ";
         std::string esp12 = esp8 + "    ";
         if (it == mAckFunctionName.begin() && it ==
-                (mAckFunctionName.end() - 1)) {
+            (mAckFunctionName.end() - 1)) {
         tpl_.listSymbol().append("addAckFunctionList", "\n" + esp8 +
             "addAcknowledgeFunctions(this) +=\n" + esp12 + ""\
             "A(\"" + *it + "\", &" + classname + "::" + *it + ");\n");
@@ -959,8 +959,7 @@ bool PluginDecision::modify(vpz::AtomicModel& model,
         clear();
         destroy();
         return true;
-    }
-    else {
+    } else {
         mDialog->hide();
         clear();
         destroy();
@@ -1039,12 +1038,26 @@ bool PluginDecision::loadPlanFile(std::string filename)
     {
         std::string ms = utils::toScientificString(it->second.minstart());
         if (ms != "-inf") {
-            mDecision->activityModel(it->first)->minstart(ms);
+            if (mDecision->activityModel(it->first)->isHumanDate())
+            {
+                std::string mshr =
+                    mDecision->toHumanRelativeDate(it->second.minstart());
+                mDecision->activityModel(it->first)->minstart(mshr);
+            } else {
+                mDecision->activityModel(it->first)->minstart(ms);
+            }
         }
 
         std::string mf = utils::toScientificString(it->second.maxfinish());
         if (mf != "inf") {
-            mDecision->activityModel(it->first)->maxfinish(mf);
+            if (mDecision->activityModel(it->first)->isHumanDate())
+            {
+                std::string mfhr =
+                    mDecision->toHumanRelativeDate(it->second.maxfinish());
+                mDecision->activityModel(it->first)->maxfinish(mfhr);
+            } else {
+                mDecision->activityModel(it->first)->maxfinish(mf);
+            }
         }
     }
 
@@ -1094,7 +1107,11 @@ void PluginDecision::writePlanFile(std::string filename)
             ackFunc = it->second->getAckFunc().at(0);
         }
         if (it->second->getRelativeDate()) {
-            relDate = "R";
+            if (it->second->isHumanDate()) {
+                relDate = "Y";
+            } else {
+                relDate = "R";
+            }
         }
         templateSave.listSymbol().append("activities", it->second->toString() +
                 "," + outputFunc + "," + ackFunc +  "," + relDate);
@@ -1160,23 +1177,34 @@ void PluginDecision::writePlanFile(std::string filename)
         std::string esp16 = "                ";
         std::string actListElem = it->second->name() + "\";\n";
         if (it->second->getRelativeDate()) {
-            if (it->second->minstart() != "" &&
+            if (it->second->minstart() != "" ||
                 it->second->maxfinish() != "") {
                 actListElem =  actListElem + "        temporal {\n";
                 if ( it->second->minstart() != "" ) {
-                    actListElem =  actListElem +
-                        esp16 + "minstart = +" +
-                        it->second->minstart() + ";\n";
+                    if (it->second->isHumanDate()) {
+                        actListElem =  actListElem +
+                            esp16 + "minstart = \"+" +
+                            it->second->minstart() + "\";\n";
+                    } else {
+                        actListElem =  actListElem +
+                            esp16 + "minstart = +" +
+                            it->second->minstart() + ";\n";
+                    }
                 }
                 if  ( it->second->maxfinish() != "" ) {
-                    actListElem =  actListElem +
-                        esp16 + "maxfinish = +" +
-                        it->second->maxfinish() + ";\n";
+                    if (it->second->isHumanDate()) {
+                        actListElem =  actListElem +
+                            esp16 + "maxfinish = \"+" +
+                            it->second->maxfinish() + "\";\n";
+                    } else {
+                        actListElem =  actListElem +
+                            esp16 + "maxfinish = +" +
+                            it->second->maxfinish() + ";\n";
+                    }
                 }
                 actListElem =  actListElem + "        }\n";
             }
-        }
-        else {
+        } else {
             if (it->second->minstart() != "" ||
                 it->second->maxfinish() != "") {
                 actListElem =  actListElem + "        temporal {\n";

--- a/vle.extension.decision/src/vle/gvle/modeling/decision/Plugin.hpp
+++ b/vle.extension.decision/src/vle/gvle/modeling/decision/Plugin.hpp
@@ -171,6 +171,8 @@ public:
     }
 
 private:
+
+    std::string toHumanDate(double date);
 /**
  * @brief Create actions for the butons group like "Select",
  * "Add Activity"...

--- a/vle.extension.decision/src/vle/gvle/modeling/decision/decision.glade
+++ b/vle.extension.decision/src/vle/gvle/modeling/decision/decision.glade
@@ -379,12 +379,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkToggleButton" id="buttonRelativeDate">
-                <property name="label" translatable="yes">Relative Dates</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
+              <object class="GtkCheckButton" id="buttonRelativeDate">
+		<property name="label" translatable="yes">Relative Dates</property>
+		<property name="visible">True</property>
+		<property name="can_focus">True</property>
+		<property name="receives_default">False</property>
+		<property name="tooltip_text" translatable="yes">To set Dates as Relatives.</property>
+		<property name="use_action_appearance">False</property>
+		<property name="draw_indicator">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/vle.extension.decision/test/parser.cpp
+++ b/vle.extension.decision/test/parser.cpp
@@ -41,10 +41,13 @@
 #include <vle/vle.hpp>
 #include <vle/value/Double.hpp>
 #include <vle/devs/Time.hpp>
+#include <vle/utils/DateTime.hpp>
 #include <vle/extension/Decision.hpp>
 
 namespace vmd = vle::extension::decision;
 namespace vd = vle::devs;
+namespace vu = vle::utils;
+
 using vle::fmt;
 using namespace boost::assign;
 
@@ -252,6 +255,13 @@ const char* Plan1 = \
 "            finish = +23.5;\n"
 "        }\n"
 "    }\n"
+"    activity {\n"
+"        id = \"activity9\";\n"
+"        temporal {\n"
+"            start = \"+0-1-2\";\n"
+"            finish = \"+3-2-1\";\n"
+"        }\n"
+"    }\n"
 "}\n"
 "\n"
 "precedences {\n"
@@ -310,7 +320,7 @@ BOOST_AUTO_TEST_CASE(parser)
     std::cout << fmt("parser: %1%\n") % b;
     std::cout << fmt("graph: %1%\n") % b.activities().precedencesGraph();
 
-    BOOST_REQUIRE_EQUAL(b.activities().size(), (vmd::Activities::size_type)8);
+    BOOST_REQUIRE_EQUAL(b.activities().size(), (vmd::Activities::size_type)9);
     BOOST_REQUIRE_EQUAL(
         b.activities().get("activity2")->second.rules().size(), 2);
     BOOST_REQUIRE_EQUAL(
@@ -351,6 +361,25 @@ BOOST_AUTO_TEST_CASE(test_relativedates)
         const vmd::Activity& act8 = b.activities().get("activity8")->second;
         BOOST_REQUIRE_EQUAL(act8.start(),15.0);
         BOOST_REQUIRE_EQUAL(act8.finish(),28.5);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_relativehumandates)
+{
+    vle::Init app;
+    {
+        vmd::ex::KnowledgeBase b;
+        b.plan().fill(std::string(vmd::ex::Plan1), 0);
+        const vmd::Activity& act9 = b.activities().get("activity9")->second;
+        BOOST_REQUIRE_EQUAL(act9.start(), 2.0);
+        BOOST_REQUIRE_EQUAL(act9.finish(), 365.0 * 3 + 31.0 + 1.0);
+    }
+    {
+        vmd::ex::KnowledgeBase b;
+        b.plan().fill(std::string(vmd::ex::Plan1), vu::DateTime::toJulianDayNumber("1966-11-08"));
+        const vmd::Activity& act9 = b.activities().get("activity9")->second;
+        BOOST_REQUIRE_EQUAL(act9.start(), vu::DateTime::toJulianDayNumber("1966-01-02"));
+        BOOST_REQUIRE_EQUAL(act9.finish(), vu::DateTime::toJulianDayNumber("1969-02-01"));
     }
 }
 


### PR DESCRIPTION
The plan file accepts relative calendar date like this "+YYYY-MM-DD"
where +YYYY stands for the number of the year. For exampple "+0-3-10"
stands for the third of february of the year n of the load date of the
plan. And "+1-11-5" stands of the fifth november of the year n+1. The
29 february is not allowed. Reklative numerical date are still
allowed.  Inside the modeling plugin. The Activity Dialog window allow
this new feature.
