### PR TITLE
ibm: add fixes ans features

### DIFF
--- a/vle.ibm/src/vle/extension/mas/Scheduler.hpp
+++ b/vle.ibm/src/vle/extension/mas/Scheduler.hpp
@@ -82,6 +82,18 @@ public:
         mElements.erase(mElements.begin());
     }
 
+    inline void removeEffect(const T& t)
+    {
+        typename std::vector<T>::iterator it;
+
+        it = std::find(mElements.begin(),mElements.end(), t);
+
+        if (it != mElements.end()) {
+            mElements.erase(it);
+        }
+    }
+
+
     inline void update(const T& t)
     {
         if (!exists(t))

--- a/vle.ibm/src/vle/ibm/ControleurProxy.cpp
+++ b/vle.ibm/src/vle/ibm/ControleurProxy.cpp
@@ -140,7 +140,13 @@ int ControleurProxy::addEvent(lua_State *L) {
     std::string type = luaL_checkstring(L, 1);
     if (type == "INIT") {
         std::string script (luaL_checkstring(L, 2));
-        script += "()";
+        std::size_t found0 = script.find("(");
+        std::size_t found1 = script.find(")");
+        if (found0 == std::string::npos &&
+            found1 == std::string::npos) {
+            std::cout << "INSIDE"<< std::endl;
+            script += "()";
+        }
         mControleur->execInit(script);
     } else if (type == "SINGLE") {
         mControleur->addEffectAt(luaL_checknumber(L, 2), vd::infinity, luaL_checkstring(L, 3));


### PR DESCRIPTION
Primitives added to lua can launch pieces of script, but also
parametrized functions.  A member method is added to the Scheduler
that does enable to remove an effect.  The controleur removes obsolete
effects.  The storage of values inside the Controler has been fixed.