### PR TITLE
gvle.discrete-time: add more metadata managment

### DIFF
--- a/gvle.discrete-time/src/DiscreteTimePanel.cpp
+++ b/gvle.discrete-time/src/DiscreteTimePanel.cpp
@@ -222,7 +222,7 @@ DiscreteTimePanel::onTableVarsMenu(const QPoint& pos)
 {
     QPoint globalPos = right->ui->tableVars->viewport()->mapToGlobal(pos);
     QModelIndex index = right->ui->tableVars->indexAt(pos);
-    QWidget* item = right->ui->tableVars->cellWidget(index.row(), index.column());
+    VleTextEdit* item = (VleTextEdit*)right->ui->tableVars->cellWidget(index.row(), index.column());
 
     QAction* action;
     QMenu menu;
@@ -237,19 +237,22 @@ DiscreteTimePanel::onTableVarsMenu(const QPoint& pos)
     QAction* selAction = menu.exec(globalPos);
     if (selAction) {
         int actCode =  selAction->data().toInt();
-        switch(actCode){
-        case 1: {//Add variable
+        switch(actCode) {
+        case 1: //Add variable
             cppMetadata->addVariableToDoc(cppMetadata->newVarNameToDoc());
             reload();
             emit undoAvailable(true);
             break;
-        } case 2: {//Add vector
+        case 2: //Add vector
 
             break;
-        } case 3: {//Remove
-
+        case 3: //Remove
+            cppMetadata->rmVariableToDoc(item->getSavedText());
+            reload();
+            emit undoAvailable(true);
             break;
-        }}
+
+        }
     }
 }
 
@@ -348,4 +351,3 @@ DiscreteTimePanel::updateConfigVar()
 
 
 }} //namespaces
-

--- a/gvle.discrete-time/src/vlesmdt.h
+++ b/gvle.discrete-time/src/vlesmdt.h
@@ -40,7 +40,6 @@
 #include <vle/value/Map.hpp>
 #include <vle/gvle/vleDomDiffStack.h>
 
-
 namespace vle {
 namespace gvle {
 
@@ -77,6 +76,8 @@ public:
     void addVariableToDoc(const QString& variableName);
     void setInitialValue(const QString& variableName,
             const vle::value::Value& val);
+    void setPortCondValue(const QString& variableName,
+            const vle::value::Value& val);
     vle::value::Value* getInitialValue(const QString& variableName);
     void rmInitialValue(const QString& variableName);
     void renameVariableToDoc(const QString& oldVariableName,
@@ -102,9 +103,31 @@ public:
     void redo();
     QString getData();
 
+    // to factorize
+    const QDomDocument& getDomDoc() const
+    { return *mDocSm; }
+
+    QDomDocument& getDomDoc()
+    { return *mDocSm; }
+
+    /**
+     * @brief create a <dynamic> tag
+     * whith dyn, attribute 'name'  set to dyn
+     */
+    QDomElement createDynamic();
+    QDomElement createObservable();
+    QDomElement createCondition();
+    QDomElement createIn();
+    QDomElement createOut();
+
+
 
 private:
     QDomNode nodeVariable(const QString& varName);
+    QDomNode nodeCondPort(const QString& portName);
+    QDomNode nodeObsPort(const QString& portName);
+    QDomNode nodeInPort(const QString& portName);
+    QDomNode nodeOutPort(const QString& portName);
 
 public slots:
     void onUndoRedoSm(QDomNode oldValSm, QDomNode newValSm);
@@ -115,9 +138,7 @@ signals:
 
     void modified();
 
-
 private:
-
 
     QDomDocument*    mDocSm;
     QString          mFileNameSrc;


### PR DESCRIPTION
When addind, renaming or removing atomic variables, metadatas related
to the observable, the condition, and the ports are managed. The
dynamic also is furnished. This enable a model to be directly
configured by the GUI.
